### PR TITLE
se arregla el problema de asociar estudio a mov de caja

### DIFF
--- a/Cedir/Main.vb
+++ b/Cedir/Main.vb
@@ -634,7 +634,7 @@ Public Class Main
         Me.BarraEstado.Name = "BarraEstado"
         Me.BarraEstado.Size = New System.Drawing.Size(978, 22)
         Me.BarraEstado.TabIndex = 5
-        Me.BarraEstado.Text = "Cedir Intranet - Versión 2.7.35- Fecha: 25/03/2015      "
+        Me.BarraEstado.Text = "Cedir Intranet - Versión 2.7.36- Fecha: 27/03/2015      "
         '
         'nfyIcon
         '

--- a/Cedir/NuevoEstudioRapidoPaso2.vb
+++ b/Cedir/NuevoEstudioRapidoPaso2.vb
@@ -375,7 +375,7 @@ Public Class NuevoEstudioRapidoPaso2
                 If currentOS <> "" Then
                     'llenar los datos en el form global
                     If hayUnaFacturacionInstanciada Then
-                        nroEstudioParaFacturacion = catalogoEstudios.obtenerUltimoNroEstudio 'para llenar este atributo hay que hacer una consulta
+                        nroEstudioParaFacturacion = est.nroEstudio 'para llenar este atributo hay que hacer una consulta
                     End If
                 Else
                     MsgBox("El estudio ha sido creado")
@@ -383,6 +383,7 @@ Public Class NuevoEstudioRapidoPaso2
                     Dim dr As DialogResult
                     dr = MessageBox.Show("Desea crear un movimiento de caja con este estudio?", "Atención", MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2)
                     If dr = Windows.Forms.DialogResult.Yes Then
+
                         Me.cargarMovimientoCaja(est)
                     End If
                 End If

--- a/CedirNegocios/Caja/MovimientoDeCaja.vb
+++ b/CedirNegocios/Caja/MovimientoDeCaja.vb
@@ -150,7 +150,6 @@ Public Class MovimientoDeCaja
         If Me.Estudio IsNot Nothing Then
             cDatos.update(com & "cedirData" & com & "." & com & "tblCajaMovimientos" & com, com & "nroEstudio" & com & " = " & _
                           Me.Estudio.nroEstudio, " where " & com & "id" & com & " = " & Id) ' ATENCION!!! ERROR
-            'NO SE ESTA SETEANDO EL NRO DE ESTUDIO
         End If
 
 

--- a/CedirNegocios/Caja/MovimientoDeCaja.vb
+++ b/CedirNegocios/Caja/MovimientoDeCaja.vb
@@ -149,7 +149,8 @@ Public Class MovimientoDeCaja
         'insertamos, si corresponde, el id del estudio asociado
         If Me.Estudio IsNot Nothing Then
             cDatos.update(com & "cedirData" & com & "." & com & "tblCajaMovimientos" & com, com & "nroEstudio" & com & " = " & _
-                          Me.Estudio.nroEstudio, " where " & com & "id" & com & " = " & Id)
+                          Me.Estudio.nroEstudio, " where " & com & "id" & com & " = " & Id) ' ATENCION!!! ERROR
+            'NO SE ESTA SETEANDO EL NRO DE ESTUDIO
         End If
 
 

--- a/CedirNegocios/Catalogos/CatalogoDeEstudios.vb
+++ b/CedirNegocios/Catalogos/CatalogoDeEstudios.vb
@@ -291,12 +291,7 @@ Public Class CatalogoDeEstudios
         resp = upd.delete("tblConsultas", com & "id" & com & " = " & idConsulta)
         Return resp
     End Function
-    Public Function obtenerUltimoNroEstudio() As Integer
-        Dim dr As NpgsqlDataReader
-        dr = da.EjecutarSelect("select max(" & com & "nroEstudio" & com & ") from " & com & "cedirData" & com & "." & com & "tblEstudios" & com)
-        dr.Read()
-        Return dr.Item(0)
-    End Function
+    
     Public Function obtenerUltimoNroConsulta() As Integer
         Dim dr As NpgsqlDataReader
         dr = da.EjecutarSelect("select max(" & com & "id" & com & ") from " & com & "cedirData" & com & "." & com & "tblConsultas" & com)
@@ -401,5 +396,6 @@ Public Class CatalogoDeEstudios
 
         drEstudios.Close()
     End Function
+
 
 End Class

--- a/CedirNegocios/Catalogos/CatalogoDeEstudios.vb
+++ b/CedirNegocios/Catalogos/CatalogoDeEstudios.vb
@@ -263,7 +263,20 @@ Public Class CatalogoDeEstudios
     Public Function traerEstudiosArancelados(ByVal condicion As String) As ArrayList
         Return loadEstudios(condicion)
     End Function
-    
+    Public Function obtenerUltimoNroEstudio() As Integer
+        Dim da As New Consultas
+        Dim dr As NpgsqlDataReader
+        Try
+            dr = da.EjecutarSelect("select max(" & com & "nroEstudio" & com & ") from " & com & "cedirData" & com & "." & com & "tblEstudios" & com)
+            dr.Read()
+            Return dr.Item(0)
+        Finally
+            da = Nothing
+            dr = Nothing
+
+        End Try
+
+    End Function
     Public Function borrarEstudio(ByVal estudio As Estudio) As String
         Dim resp As String
         Dim condicion As String

--- a/CedirNegocios/Catalogos/CatalogoDeMovimientosDeCaja.vb
+++ b/CedirNegocios/Catalogos/CatalogoDeMovimientosDeCaja.vb
@@ -123,7 +123,7 @@ Public Class CatalogoDeMovimientosDeCaja
             tipoMov.descripcion = Convert.ToString(dr("descripcion"))
             oCajaMov.TipoDeMovimiento = tipoMov
 
-            If dr("fechaEstudio") Is DBNull.Value Then
+            If dr("fechaEstudio") Is DBNull.Value Then 'aca esta el problema. no se esta seteando la fecha, cuando se asocia al mov.
                 oCajaMov.Estudio = Nothing
             Else
                 vEstudio = New Estudio

--- a/CedirNegocios/Catalogos/CatalogoDeMovimientosDeCaja.vb
+++ b/CedirNegocios/Catalogos/CatalogoDeMovimientosDeCaja.vb
@@ -123,7 +123,7 @@ Public Class CatalogoDeMovimientosDeCaja
             tipoMov.descripcion = Convert.ToString(dr("descripcion"))
             oCajaMov.TipoDeMovimiento = tipoMov
 
-            If dr("fechaEstudio") Is DBNull.Value Then 'aca esta el problema. no se esta seteando la fecha, cuando se asocia al mov.
+            If dr("fechaEstudio") Is DBNull.Value Then
                 oCajaMov.Estudio = Nothing
             Else
                 vEstudio = New Estudio

--- a/CedirNegocios/Estudio.vb
+++ b/CedirNegocios/Estudio.vb
@@ -275,6 +275,7 @@ Public Class Estudio
         If resp = "ok" Then
             Return crearEstudio()
         End If
+
         Return "Error"
 
     End Function
@@ -314,10 +315,11 @@ Public Class Estudio
 
         Dim resp As String = ""
         Dim upd As New CedirDataAccess.Nuevo
-        Dim publicId As String = Me.obtenerNuevoPublicID()
+        Me.publicID = Me.obtenerNuevoPublicID()
 
         'Al modificar esto, revisar código btnAnunciar en Turnos
-        resp = upd.nuevoEstudio(publicId, Me.paciente.Id, Me.practica.idEstudio, Me.motivoEstudio, Me.informe, Me.medicoActuante.idMedico, Me.medicoSolicitante.idMedico, Me.obraSocial.idObraSocial, Me.fechaEstudio, Me.nroOrden, Me.Anestesista.idMedico, Me.VideoEstudio.enlaceMega.Trim())
+        resp = upd.nuevoEstudio(me.publicId, Me.paciente.Id, Me.practica.idEstudio, Me.motivoEstudio, Me.informe, Me.medicoActuante.idMedico, Me.medicoSolicitante.idMedico, Me.obraSocial.idObraSocial, Me.fechaEstudio, Me.nroOrden, Me.Anestesista.idMedico, Me.VideoEstudio.enlaceMega.Trim())
+        resp = Me.obtenerUltimoNroEstudio()
 
         'Log the action
         Dim sSecurity As Security = Security.GetInstance()
@@ -579,4 +581,26 @@ Public Class Estudio
         Next
         Return arr
     End Function
+
+    Public Function obtenerUltimoNroEstudio() As String
+        Dim da As New Consultas
+        Dim dr As NpgsqlDataReader
+        Try
+            dr = da.EjecutarSelect("select max(" & com & "nroEstudio" & com & ") from " & com & "cedirData" & com & "." & com & "tblEstudios" & com)
+            dr.Read()
+            Me.nroEstudio = dr.Item(0)
+            Return "ok"
+        Catch ex As Exception
+            Return ""
+        Finally
+            da = Nothing
+            dr = Nothing
+
+        End Try
+
+    End Function
+
+
 End Class
+
+

--- a/CedirNegocios/Estudio.vb
+++ b/CedirNegocios/Estudio.vb
@@ -315,22 +315,34 @@ Public Class Estudio
 
         Dim resp As String = ""
         Dim upd As New CedirDataAccess.Nuevo
-        Me.publicID = Me.obtenerNuevoPublicID()
-
-        'Al modificar esto, revisar código btnAnunciar en Turnos
-        resp = upd.nuevoEstudio(me.publicId, Me.paciente.Id, Me.practica.idEstudio, Me.motivoEstudio, Me.informe, Me.medicoActuante.idMedico, Me.medicoSolicitante.idMedico, Me.obraSocial.idObraSocial, Me.fechaEstudio, Me.nroOrden, Me.Anestesista.idMedico, Me.VideoEstudio.enlaceMega.Trim())
-        resp = Me.obtenerUltimoNroEstudio()
-
-        'Log the action
-        Dim sSecurity As Security = Security.GetInstance()
-        Dim cUsuario As Usuario = sSecurity.getLoggedUser()
         Dim vLog As New AuditLog
-        vLog.usuario = cUsuario
-        vLog.objectId = Me.nroEstudio
-        vLog.objectTypeId = 1
-        vLog.userActionId = 1
-        vLog.create()
+        Dim catEstudios As New CatalogoDeEstudios
+        Try
+            Me.publicID = Me.obtenerNuevoPublicID()
 
+            'Al modificar esto, revisar código btnAnunciar en Turnos
+            resp = upd.nuevoEstudio(Me.publicID, Me.paciente.Id, Me.practica.idEstudio, Me.motivoEstudio, Me.informe, Me.medicoActuante.idMedico, Me.medicoSolicitante.idMedico, Me.obraSocial.idObraSocial, Me.fechaEstudio, Me.nroOrden, Me.Anestesista.idMedico, Me.VideoEstudio.enlaceMega.Trim())
+
+            Me.nroEstudio = catEstudios.obtenerUltimoNroEstudio
+
+            'Log the action
+            Dim sSecurity As Security = Security.GetInstance()
+            Dim cUsuario As Usuario = sSecurity.getLoggedUser()
+
+            vLog.usuario = cUsuario
+            vLog.objectId = Me.nroEstudio
+            vLog.objectTypeId = 1
+            vLog.userActionId = 1
+            vLog.create()
+
+        Finally
+
+            upd = Nothing
+            vLog = Nothing
+            catEstudios = Nothing
+
+        End Try
+        
         Return resp
 
     End Function
@@ -582,23 +594,7 @@ Public Class Estudio
         Return arr
     End Function
 
-    Public Function obtenerUltimoNroEstudio() As String
-        Dim da As New Consultas
-        Dim dr As NpgsqlDataReader
-        Try
-            dr = da.EjecutarSelect("select max(" & com & "nroEstudio" & com & ") from " & com & "cedirData" & com & "." & com & "tblEstudios" & com)
-            dr.Read()
-            Me.nroEstudio = dr.Item(0)
-            Return "ok"
-        Catch ex As Exception
-            Return ""
-        Finally
-            da = Nothing
-            dr = Nothing
-
-        End Try
-
-    End Function
+    
 
 
 End Class


### PR DESCRIPTION
@walterbrunetti 

Esta solucionado el problema. 

Ver que cuando se creaba un estudio, no se estaba trayendo de la db el nuevo nro de estudio creado en la db automaticamente. 

Entonces, no se estaba asociando el mov. de caja, con un nro de estudio correcto. 

