### PR TITLE
- Pasa connection string y URL de los webservices de la AFIP al app.c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 *.suo
 
 #Directories
-/singleton
+Singleton/bin
+Singleton/obj
 Cedir/bin
 Cedir/obj
 CedirDataAccess/bin
@@ -21,3 +22,4 @@ obj/
 *.resx
 *.config
 FacturaElectronica/My Proyect/
+Singleton/My Project/

--- a/Cedir/app.config
+++ b/Cedir/app.config
@@ -1,27 +1,52 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <configSections>
-    </configSections>
-    <system.diagnostics>
-        <sources>
-            <!-- En esta sección se define la configuración del registro para My.Application.Log -->
-            <source name="DefaultSource" switchName="DefaultSwitch">
-                <listeners>
-                    <add name="FileLog"/>
-                    <!-- Quite los comentarios de la sección posterior para escribir en el registro de eventos de la aplicación -->
-                    <!--<add name="EventLog"/>-->
-                </listeners>
-            </source>
-        </sources>
-        <switches>
-            <add name="DefaultSwitch" value="Information" />
-        </switches>
-        <sharedListeners>
-            <add name="FileLog"
-                 type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
-                 initializeData="FileLogWriter"/>
-            <!-- Quite los comentarios de la sección posterior y reemplace APPLICATION_NAME con el nombre de su aplicación para escribir en el registro de sucesos de la aplicación -->
-            <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
-        </sharedListeners>
-    </system.diagnostics>
+  <configSections>
+    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+      <section name="FacturaElectronica.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+  <appSettings>
+  </appSettings>
+  <applicationSettings>
+    <FacturaElectronica.My.MySettings>
+      <setting name="FacturaElectronica_ar_gov_afip_wsaahomo_LoginCMSService"
+          serializeAs="String">
+        <value>https://wsaahomo.afip.gov.ar/ws/services/LoginCms</value>
+      </setting>
+      <setting name="FacturaElectronica_ar_gov_afip_wswhomo_Service"
+          serializeAs="String">
+        <value>https://wswhomo.afip.gov.ar/wsfev1/service.asmx</value>
+      </setting>
+      <setting name="rutaClaveCertificadoFE" serializeAs="String">
+        <value>Claves\{0}.pfx</value>
+      </setting>
+    </FacturaElectronica.My.MySettings>
+  </applicationSettings>
+  <connectionStrings>
+    <add name="Default"
+         connectionString="Encoding=UNICODE;Server=127.0.0.1;Port=5432;User Id=postgres;Password=Devel$1234;Database=PruebasCedirFE"
+         providerName="System.Data.SqlClient"/>
+  </connectionStrings>
+  <system.diagnostics>
+    <sources>
+      <!-- En esta sección se define la configuración del registro para My.Application.Log -->
+      <source name="DefaultSource" switchName="DefaultSwitch">
+        <listeners>
+          <add name="FileLog"/>
+          <!-- Quite los comentarios de la sección posterior para escribir en el registro de eventos de la aplicación -->
+          <!--<add name="EventLog"/>-->
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="DefaultSwitch" value="Information" />
+    </switches>
+    <sharedListeners>
+      <add name="FileLog"
+           type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+           initializeData="FileLogWriter"/>
+      <!-- Quite los comentarios de la sección posterior y reemplace APPLICATION_NAME con el nombre de su aplicación para escribir en el registro de sucesos de la aplicación -->
+      <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
+    </sharedListeners>
+  </system.diagnostics>
 </configuration>

--- a/FacturaElectronica/Factura Electronica/Autenticador/LoginTicket.vb
+++ b/FacturaElectronica/Factura Electronica/Autenticador/LoginTicket.vb
@@ -16,7 +16,7 @@ Imports Microsoft.VisualBasic
     ' Momento en que fue generado el requerimiento 
     Public GenerationTime As DateTime
     ' Momento en el que exoira la solicitud 
-    Public ExpirationTime As DateTimeOffset
+    Public ExpirationTime As DateTime
     ' Firma de seguridad recibida en la respuesta 
     Public Sign As String
     ' Token de seguridad recibido en la respuesta 

--- a/FacturaElectronica/Factura Electronica/Autenticador/LoginTicket.vb
+++ b/FacturaElectronica/Factura Electronica/Autenticador/LoginTicket.vb
@@ -16,9 +16,7 @@ Imports Microsoft.VisualBasic
     ' Momento en que fue generado el requerimiento 
     Public GenerationTime As DateTime
     ' Momento en el que exoira la solicitud 
-    Public ExpirationTime As DateTime
-    ' Identificacion del WSN para el cual se solicita el TA 
-    Public Service As String
+    Public ExpirationTime As DateTimeOffset
     ' Firma de seguridad recibida en la respuesta 
     Public Sign As String
     ' Token de seguridad recibido en la respuesta 
@@ -37,10 +35,9 @@ Imports Microsoft.VisualBasic
     ''' Construye un Login Ticket obtenido del WSAA 
     '''</summary> 
     '''<param name="argServicio">Servicio al que se desea acceder</param> 
-    '''<param name="argUrlWsaa">URL del WSAA</param> 
     '''<param name="argRutaCertX509Firmante">Ruta del certificado X509 (con clave privada) usado para firmar</param> 
     '''<remarks></remarks> 
-    Public Function ObtenerLoginTicketResponse(ByVal argServicio As String, ByVal argUrlWsaa As String, ByVal argRutaCertX509Firmante As String, ByVal password As String) As String
+    Public Function ObtenerLoginTicketResponse(ByVal argServicio As String, ByVal argRutaCertX509Firmante As String, ByVal password As String) As String
         Dim cmsFirmadoBase64 As String
         Dim loginTicketResponse As String
 
@@ -67,8 +64,6 @@ Imports Microsoft.VisualBasic
             xmlNodoExpirationTime.InnerText = DateTime.Now.AddMinutes(+10).ToString("s")
             xmlNodoUniqueId.InnerText = CStr(_globalUniqueID)
             xmlNodoService.InnerText = argServicio
-            Me.Service = argServicio
-
 
 
         Catch excepcionAlGenerarLoginTicketRequest As Exception

--- a/FacturaElectronica/Factura Electronica/ClienteFacturaElectronica/ClienteFE.vb
+++ b/FacturaElectronica/Factura Electronica/ClienteFacturaElectronica/ClienteFE.vb
@@ -40,7 +40,7 @@ Public Class ClienteFE
     ''' <remarks></remarks>
     Private Sub InicializarAutenticador(ByVal responsable As String)
         If lt.ExpirationTime <= DateTime.Now Then
-            lt.ObtenerLoginTicketResponse("wsfe", "https://wsaahomo.afip.gov.ar/ws/services/LoginCms?wsdl", GetKeyLocationFromResponsable(responsable), GetPasswordFromResponsable(responsable))
+            lt.ObtenerLoginTicketResponse("wsfe", GetKeyLocationFromResponsable(responsable), GetPasswordFromResponsable(responsable))
         End If
     End Sub
 

--- a/FacturaElectronica/FacturaElectronica.vbproj
+++ b/FacturaElectronica/FacturaElectronica.vbproj
@@ -85,9 +85,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="Factura Electronica\claves\certificado.pfx">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="My Project\Application.myapp">
       <Generator>MyApplicationCodeGenerator</Generator>
       <LastGenOutput>Application.Designer.vb</LastGenOutput>

--- a/FacturaElectronica/app.config
+++ b/FacturaElectronica/app.config
@@ -28,17 +28,18 @@
         </sharedListeners>
     </system.diagnostics>
     <applicationSettings>
+        <!-- Esta sección está presente sólo para definir las propiedades, pero los valores son obtenidos del app.config de la aplicación. -->
         <FacturaElectronica.My.MySettings>
             <setting name="FacturaElectronica_ar_gov_afip_wsaahomo_LoginCMSService"
                 serializeAs="String">
-                <value>https://wsaahomo.afip.gov.ar/ws/services/LoginCms</value>
+                <value></value>
             </setting>
             <setting name="FacturaElectronica_ar_gov_afip_wswhomo_Service"
                 serializeAs="String">
-                <value>https://wswhomo.afip.gov.ar/wsfev1/service.asmx</value>
+                <value></value>
             </setting>
             <setting name="rutaClaveCertificadoFE" serializeAs="String">
-                <value>Claves\{0}.pfx</value>
+                <value></value>
             </setting>
         </FacturaElectronica.My.MySettings>
     </applicationSettings>

--- a/Singleton/AssemblyInfo.vb
+++ b/Singleton/AssemblyInfo.vb
@@ -1,0 +1,32 @@
+Imports System
+Imports System.Reflection
+Imports System.Runtime.InteropServices
+
+' La información general de un ensamblado se controla mediante el siguiente
+' conjunto de atributos. Cambie estos atributos para modificar la información
+' asociada con un ensamblado.
+
+' Revisar los valores de los atributos del ensamblado
+
+<Assembly: AssemblyTitle("")> 
+<Assembly: AssemblyDescription("")> 
+<Assembly: AssemblyCompany("")> 
+<Assembly: AssemblyProduct("")> 
+<Assembly: AssemblyCopyright("")> 
+<Assembly: AssemblyTrademark("")> 
+<Assembly: CLSCompliant(True)> 
+
+'El siguiente GUID sirve como identificador de la biblioteca de tipos si este proyecto se expone a COM
+<Assembly: Guid("B7633A36-E1EF-4A5E-8229-7F395E98FEE1")> 
+
+' La información de versión de un ensamblado consta de los siguientes cuatro valores:
+'
+'      Versión principal
+'      Versión secundaria 
+'      Versión de compilación
+'      Revisión
+'
+' Puede especificar todos los valores o usar los valores predeterminados (número de versión de compilación y de revisión) 
+' usando el símbolo '*' como se muestra a continuación:
+
+<Assembly: AssemblyVersion("1.0.*")> 

--- a/Singleton/DbConnectionSingleton.vb
+++ b/Singleton/DbConnectionSingleton.vb
@@ -1,0 +1,37 @@
+Imports System.Threading
+Imports System.Configuration
+Imports Npgsql
+Public Class DbConnectionSingleton
+    Private Shared _singleton As DbConnectionSingleton
+    Private Shared _mu As New Mutex
+
+    Dim myConnection As NpgsqlConnection
+    Private Sub New()
+        myConnection = New NpgsqlConnection(ConfigurationManager.ConnectionStrings("Default").ConnectionString)
+        myConnection.Open()
+    End Sub
+
+    Public Shared Function GetInstance() As DbConnectionSingleton
+        _mu.WaitOne()
+
+        Try
+            If _singleton Is Nothing Then
+                _singleton = New DbConnectionSingleton
+            End If
+
+        Finally
+            _mu.ReleaseMutex()
+        End Try
+
+        Return _singleton
+
+    End Function
+
+    Public Function getDbConnection() As NpgsqlConnection
+        'If myConnection.state = 0 Then 'borrar comentario
+        'myConnection.Open()
+        'End If
+        Return myConnection
+    End Function
+
+End Class

--- a/Singleton/Singleton.vbproj
+++ b/Singleton/Singleton.vbproj
@@ -1,0 +1,145 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <BaseAddress>285212672</BaseAddress>
+    <DocumentationFile>Singleton.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <WarningLevel>1</WarningLevel>
+    <NoWarn>42016,42017,42018,42019,42032</NoWarn>
+    <DebugType>
+    </DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectType>Local</ProjectType>
+    <ProductVersion>8.0.50727</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{602E81C4-A9FD-43AA-A806-D1471AC25C42}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
+    <AssemblyName>Singleton</AssemblyName>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyMode>None</AssemblyOriginatorKeyMode>
+    <DefaultClientScript>JScript</DefaultClientScript>
+    <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
+    <DefaultTargetSchema>IE50</DefaultTargetSchema>
+    <DelaySign>false</DelaySign>
+    <OutputType>Library</OutputType>
+    <OptionCompare>Binary</OptionCompare>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionStrict>Off</OptionStrict>
+    <RootNamespace>Singleton</RootNamespace>
+    <StartupObject>
+    </StartupObject>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <MyType>Windows</MyType>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>bin\</OutputPath>
+    <DocumentationFile>Singleton.xml</DocumentationFile>
+    <BaseAddress>285212672</BaseAddress>
+    <ConfigurationOverrideFile>
+    </ConfigurationOverrideFile>
+    <DefineConstants>
+    </DefineConstants>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <RemoveIntegerChecks>false</RemoveIntegerChecks>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningLevel>1</WarningLevel>
+    <NoWarn>42016,42017,42018,42019,42032</NoWarn>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>bin\</OutputPath>
+    <DocumentationFile>Singleton.xml</DocumentationFile>
+    <BaseAddress>285212672</BaseAddress>
+    <ConfigurationOverrideFile>
+    </ConfigurationOverrideFile>
+    <DefineConstants>
+    </DefineConstants>
+    <DefineDebug>false</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <DebugSymbols>false</DebugSymbols>
+    <Optimize>true</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <RemoveIntegerChecks>false</RemoveIntegerChecks>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningLevel>1</WarningLevel>
+    <NoWarn>42016,42017,42018,42019,42032</NoWarn>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineDebug>true</DefineDebug>
+    <DefineTrace>true</DefineTrace>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <BaseAddress>285212672</BaseAddress>
+    <DocumentationFile>Singleton.xml</DocumentationFile>
+    <WarningLevel>1</WarningLevel>
+    <NoWarn>42016,42017,42018,42019,42032</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Mono.Security, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756" />
+    <Reference Include="Npgsql, Version=1.0.5000.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7" />
+    <Reference Include="System">
+      <Name>System</Name>
+    </Reference>
+    <Reference Include="System.configuration" />
+    <Reference Include="System.Data">
+      <Name>System.Data</Name>
+    </Reference>
+    <Reference Include="System.Xml">
+      <Name>System.XML</Name>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Import Include="Microsoft.VisualBasic" />
+    <Import Include="System" />
+    <Import Include="System.Collections" />
+    <Import Include="System.Data" />
+    <Import Include="System.Diagnostics" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.vb">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="DbConnectionSingleton.vb">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="My Project\Settings.Designer.vb">
+      <AutoGen>True</AutoGen>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="My Project\Settings.settings">
+      <CustomToolNamespace>My</CustomToolNamespace>
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.vb</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
@walterbrunetti con estos cambios:

- el connection string y la url de los webservices de la AFIP son leidos desde el archivo "Cedir.exe.config" al iniciarse la aplicación dando mayor flexibilidad en la configuración. Este archivo es generado automáticamente, durante la compilación, a partir del archivo "app.conf" del proyecto "Cedir".

- el proyecto "Singleton" se puede agregar al versionado porque ahora no contienen ningún secreto.