### PR TITLE
Al abrir una presentación, tanto la factura, como la NC que la "anula…

### DIFF
--- a/CedirNegocios/Comprobantes/Comprobante.vb
+++ b/CedirNegocios/Comprobantes/Comprobante.vb
@@ -531,7 +531,7 @@ Public Class Comprobante
             result.DocumentoCliente.Descripcion = "CUIT"
 
             result.DomicilioCliente = Me.DomicilioCliente
-            result.Estado = "NO COBRADO"
+            result.Estado = "COBRADO"
             result.Factura = Me
             result.FechaEmision = Date.Today
             result.Gravado = Me.Gravado

--- a/CedirNegocios/Presentacion.vb
+++ b/CedirNegocios/Presentacion.vb
@@ -368,7 +368,8 @@ Public Class Presentacion
 
     Public Sub anularComprobante() 'este metodo anula el comprobante al abrir la presentacion
         Dim cDatos As New Nuevo
-        Dim resp As String = cDatos.update(com & "cedirData" & com & "." & com & "tblFacturacion" & com, com & "idComprobante" & com & " = " & "NULL, " & com & "pagado" & com & " = " & "2", " where " & com & "idFacturacion" & com & " = " & Me.idPresentacion)
+        cDatos.update(com & "cedirData" & com & "." & com & "tblFacturacion" & com, com & "idComprobante" & com & " = " & "NULL, " & com & "pagado" & com & " = " & "2", " where " & com & "idFacturacion" & com & " = " & Me.idPresentacion)
+        cDatos.update(com & "cedirData" & com & "." & com & "tblComprobantes" & com, com & "estado" & com & " = " & "'COBRADO'", " where " & com & "id" & com & " = " & Me.comprobante.IdComprobante)
         cDatos = Nothing
     End Sub
 


### PR DESCRIPTION
@walterbrunetti con estos cambios, al abrir una presentación, tanto la factura anterior, como la NC que la anula quedan en estado "COBRADO" (como observó Mariana en su correo).